### PR TITLE
Fix port redirection for CouchDB

### DIFF
--- a/scripts/cozy_dev_setup.sh
+++ b/scripts/cozy_dev_setup.sh
@@ -2,6 +2,9 @@
 
 apt-get -y -qq install couchdb curl git imagemagick python openssl wget sqlite3 build-essential python-dev python-setuptools python-pip libssl-dev libxml2-dev libxslt1-dev npm nodejs nodejs-legacy supervisor
 
+sed -i -e 's/127.0.0.1/0.0.0.0/' /etc/couchdb/default.ini
+service couchdb restart
+
 useradd -M cozy
 useradd -M cozy-data-system
 useradd -M cozy-home


### PR DESCRIPTION
In the Vagrantfile generated by cozy-dev, a port redirection is active for port 5984 (CouchDB). Vagrant expects that a process listens on this port on any interface (0.0.0.0). It does not work when CouchDB listens on 127.0.0.1:5984. Thus this change to make CouchDB listens on 0.0.0.0:5984.
